### PR TITLE
Add feedstock-name option

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,6 +64,7 @@ about:
   summary: 'Command line tools for the Gazebo libraries.'
 
 extra:
+  feedstock-name: {{ repo_name }}
   recipe-maintainers:
     - wolfv
     - traversaro


### PR DESCRIPTION
Useless at this point as the feedstock is already named `gz-tools2-feedstock`, but at least we avoid future similar problems due to copy&paste, see https://github.com/conda-forge/staged-recipes/pull/20611#issuecomment-1267367547 .