### PR TITLE
Reintroduce fix on backward lib loading patch and align conda-forge.yml with ignition feedstock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About gz-tools2
-===============
+About gz-tools
+==============
 
 Home: https://github.com/gazebosim/gz-tools
 
@@ -77,10 +77,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-gz--tools2-green.svg)](https://anaconda.org/conda-forge/gz-tools2) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gz-tools2.svg)](https://anaconda.org/conda-forge/gz-tools2) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gz-tools2.svg)](https://anaconda.org/conda-forge/gz-tools2) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gz-tools2.svg)](https://anaconda.org/conda-forge/gz-tools2) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libgz--tools2-green.svg)](https://anaconda.org/conda-forge/libgz-tools2) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libgz-tools2.svg)](https://anaconda.org/conda-forge/libgz-tools2) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libgz-tools2.svg)](https://anaconda.org/conda-forge/libgz-tools2) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libgz-tools2.svg)](https://anaconda.org/conda-forge/libgz-tools2) |
 
-Installing gz-tools2
-====================
+Installing gz-tools
+===================
 
-Installing `gz-tools2` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `gz-tools` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -166,17 +166,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating gz-tools2-feedstock
-============================
+Updating gz-tools-feedstock
+===========================
 
-If you would like to improve the gz-tools2 recipe or build a new
+If you would like to improve the gz-tools recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/gz-tools2-feedstock are
+Note that all branches in the conda-forge/gz-tools-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,7 @@
+build_platform: {osx_arm64: osx_64}
+conda_forge_output_validation: true
+provider: {linux_aarch64: default, linux_ppc64le: default}
+test_on_native_only: true
 github:
   branch_name: main
   tooling_branch_name: main
-conda_forge_output_validation: true

--- a/recipe/fix_backward_install.patch
+++ b/recipe/fix_backward_install.patch
@@ -1,0 +1,16 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a80a014..f84dd1e 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -39,8 +39,9 @@ install (TARGETS backward
+ 
+ #===============================================================================
+ # Used for the installed version.
+-if(APPLE)
+-  # On macOS, the full path to the library since DYLD_LIBRARY_PATH may not work.
++if(NOT WIN32)
++  # If we are not on Windows specify the full path as the different ways that dlopen
++  # has to find libraries without full path may not work (while on Windows PATH should work)
+   set(backward_library_name ${CMAKE_INSTALL_FULL_LIBDIR}/$<TARGET_FILE_NAME:backward>)
+ else()
+   set(backward_library_name $<TARGET_FILE_NAME:backward>)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ package:
 source:
   - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ major_version }}_{{ version }}.tar.gz
     sha256: 5e3788d5a1d5fa40724f1484cda716e0c050f01d2c516efa9f8a00877e74ef64
+    patches:
+      - fix_backward_install.patch 
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - fix_backward_install.patch 
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
I had removed the patch that is present in `libignition-tools-feedstock` (see https://github.com/conda-forge/libignition-tools-feedstock/blob/main/recipe/fix-backward-install.patch) in https://github.com/conda-forge/staged-recipes/pull/20611, because it was not clear to me the logic, and for sure it was not working on Windows as the backward dll on Windows is not installed in `${CMAKE_INSTALL_FULL_LIBDIR}` . After looking a bit more into it, I realized that also on Linux there are several reason for which the `dlopen` could not find the library installed in `$CONDA_PREFIX/lib`, as `dlopen` finds library without the full path in this conditions (see https://man7.org/linux/man-pages/man3/dlopen.3.html):

>      If filename is NULL, then the returned handle is for the main
>       program.  If filename contains a slash ("/"), then it is
>       interpreted as a (relative or absolute) pathname.  Otherwise, the
>       dynamic linker searches for the object as follows (see [ld.so(8)](https://man7.org/linux/man-pages/man8/ld.so.8.html)
>       for further details):
>
>       o   (ELF only) If the calling object (i.e., the shared library or
>           executable from which dlopen() is called) contains a DT_RPATH
>           tag, and does not contain a DT_RUNPATH tag, then the
>           directories listed in the DT_RPATH tag are searched.
>
>       o   If, at the time that the program was started, the environment
>           variable LD_LIBRARY_PATH was defined to contain a colon-
>           separated list of directories, then these are searched.  (As
>           a security measure, this variable is ignored for set-user-ID
>           and set-group-ID programs.)
>
>       o   (ELF only) If the calling object contains a DT_RUNPATH tag,
>           then the directories listed in that tag are searched.
>
>       o   The cache file /etc/ld.so.cache (maintained by [ldconfig(8)](https://man7.org/linux/man-pages/man8/ldconfig.8.html))
>           is checked to see whether it contains an entry for filename.
>
>       o   The directories /lib and /usr/lib are searched (in that
>           order).

In apt installations of `gz-tools` everything works fine as the lib is installed in `/usr/lib`.

For these reasons, I modified the logic to always specify the file with full path if we are not on Windows. On Windows, everything should work fine even without any full path as the Windows equivalent of dlopen looks into `PATH`.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
