### PR TITLE
Cleanup ruby dependency

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,8 +8,11 @@ jobs:
     vmImage: windows-2019
   strategy:
     matrix:
-      win_64_:
-        CONFIG: win_64_
+      win_64_ruby2.5:
+        CONFIG: win_64_ruby2.5
+        UPLOAD_PACKAGES: 'True'
+      win_64_ruby2.6:
+        CONFIG: win_64_ruby2.6
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/win_64_ruby2.5.yaml
+++ b/.ci_support/win_64_ruby2.5.yaml
@@ -1,0 +1,12 @@
+c_compiler:
+- vs2019
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+ruby:
+- '2.5'
+target_platform:
+- win-64

--- a/.ci_support/win_64_ruby2.6.yaml
+++ b/.ci_support/win_64_ruby2.6.yaml
@@ -6,5 +6,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+ruby:
+- '2.6'
 target_platform:
 - win-64

--- a/README.md
+++ b/README.md
@@ -104,10 +104,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64</td>
+              <td>win_64_ruby2.5</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17566&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-tools2-feedstock?branchName=main&jobName=win&configuration=win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-tools2-feedstock?branchName=main&jobName=win&configuration=win_64_ruby2.5" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_ruby2.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17566&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-tools2-feedstock?branchName=main&jobName=win&configuration=win_64_ruby2.6" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - fix_backward_install.patch 
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ cxx_name }}
@@ -26,21 +26,22 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage(cxx_name, max_pin='x') }}
+      ignore_run_exports:
+        - ruby
     requirements:
       build:
         - {{ compiler('cxx') }}
         - {{ compiler('c') }}
-        - ruby                               # [not win]
-        - ruby 2.7                           # [win]
         - ninja
         - cmake
         - pkg-config
       host:
         - libgz-cmake3
         - backward-cpp
-      run:
         - ruby                               # [not win]
         - ruby 2.7                           # [win]
+      run:
+        - ruby
         - elfutils                           # [linux]
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,8 @@ outputs:
       host:
         - libgz-cmake3
         - backward-cpp
-        - ruby                               # [not win]
-        - ruby 2.7                           # [win]
+        - ruby                               # [not (win or (osx and arm64))]
+        - ruby 2.7                           # [win or (osx and arm64)]
       run:
         - ruby
         - elfutils                           # [linux]


### PR DESCRIPTION
Triggered by https://github.com/conda-forge/libsdformat-feedstock/pull/70#issuecomment-1272497559 . 

Changes:
  * Move the ruby dependency from build to host, as for cross-compiled builds the ruby install should be the target one
  * Remove the hard specification of ruby on Windows run dependencies (add added `ignore_run_exports` to ensure these are not added), as this packages does not compila anything against ruby ffi, so any recent ruby is ok to be installed at runtime


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
